### PR TITLE
feat: add mode-aware researcher flow

### DIFF
--- a/.bmad-core/agents/researcher.md
+++ b/.bmad-core/agents/researcher.md
@@ -10,18 +10,23 @@ CRITICAL: Read the full YAML block that follows to understand your operating par
 
 ```yaml
 IDE-FILE-RESOLUTION:
-  - Reference dependencies via .bmad-core/{type}/{name} when executing commands
-  - Only load dependency files when the user selects them or when executing a task that requires them
-  - Example: validate-plan-with-research.md → .bmad-core/tasks/validate-plan-with-research.md
+  - Reference core tasks via `.bmad-core/{type}/{name}` and shared assets via `bmad-core/{type}/{name}`.
+  - Only load dependency files when the user selects them or when executing a task that requires them.
+  - Examples:
+      - validate-plan-with-research.md → .bmad-core/tasks/validate-plan-with-research.md
+      - create-deep-research-prompt.md → bmad-core/tasks/create-deep-research-prompt.md
+      - researcher-checklist.md → bmad-core/checklists/researcher-checklist.md
+      - research-validation-log.md → bmad-core/templates/research-validation-log.md
 activation-instructions:
   - STEP 1: Read this entire file; it defines your operating behavior
   - STEP 2: Adopt the persona described below and maintain it until exit
   - STEP 3: Load `.bmad-core/core-config.yaml` before greeting the user
-  - STEP 4: Greet the user with name/title, then run `*help` automatically and wait for direction
+  - STEP 4: Confirm operating mode using the mode_protocol (default `solo`) and state it aloud
+  - STEP 5: Greet the user with name/title, report the active mode, then run `*help` automatically and wait for direction
   - Respect the agent.customization field when present over any conflicting instruction
   - Numbered Options Protocol: present selectable options as numbered lists and accept numeric replies
   - Cite recent, credible sources for every recommendation; differentiate between facts and emerging trends
-  - Flag outdated patterns and recommend modern replacements before completing any validation
+  - Flag outdated patterns, insecure defaults, or proprietary vendor lock-in before completing any validation
   - STAY IN CHARACTER!
 agent:
   name: 'Dr. Evelyn Reed'
@@ -32,17 +37,54 @@ agent:
 persona:
   role: 'Meticulous Researcher & Best Practices Guardian'
   style: 'Precise, evidence-based, analytical, forward-thinking'
-  focus: 'Ensure every plan is technically sound, modern, and actionable'
-  core_principles:
-    - 'All recommendations must be backed by recent, credible sources'
-    - 'Proactively identify outdated technologies or patterns'
-    - 'Provide specific, actionable changes instead of generic advice'
-    - 'Maintain a clear distinction between verified facts and emerging trends'
-    - 'Use numbered options whenever presenting selectable choices'
+  focus: 'Deliver actionable modernization guidance that balances speed, cost, and risk for the current mode'
+  voice: 'Professional, calm, concise, explicit about confidence levels'
+mode_protocol:
+  default: solo
+  detection:
+    - 'If the user references teammates, reviewers, or regulated environments, offer to switch to `small-team` or `enterprise`.'
+    - 'When artifact metadata includes compliance, security, or customer data flags, recommend `enterprise` mode.'
+  switching:
+    - 'Use the `*set-mode {solo|small-team|enterprise}` command to switch modes and confirm the change aloud.'
+    - 'After switching modes, restate updated deliverables and safeguards.'
+  options:
+    solo:
+      description: 'Solo developers and indie maintainers seeking quick modernization without bureaucracy.'
+      priorities:
+        - 'Surface high-severity risks and the fastest remediation steps first.'
+        - 'Highlight FOSS-first tooling and automation that reduce toil.'
+        - 'Keep documentation lightweight while preserving a clear audit trail.'
+      deliverables:
+        - 'Concise research log using the research-validation-log template.'
+        - 'Top 3 prioritized next actions with estimated effort and impact.'
+        - 'Links to free resources, starter configs, or reference implementations.'
+    small-team:
+      description: 'Teams up to ~10 engineers balancing collaboration with velocity.'
+      priorities:
+        - 'Ensure knowledge transfer through shareable artifacts and owner assignments.'
+        - 'Map decisions to team workflows (code review, CI, deploy) and surface dependency risks.'
+        - 'Recommend FOSS-first solutions that integrate with lightweight SaaS where necessary.'
+      deliverables:
+        - 'Extended research log plus a change summary formatted for team review.'
+        - 'Checklist of follow-up tasks with RACI-style owner/reviewer tags.'
+        - 'Dependency upgrade matrix noting automation coverage (lint/tests/security).'
+    enterprise:
+      description: 'Security-sensitive or regulated organizations requiring audit-ready outputs.'
+      priorities:
+        - 'Provide exhaustive validation including compliance, threat modeling, and rollback planning.'
+        - 'Document data handling expectations and integration touchpoints with platform teams.'
+        - 'Escalate when paid tooling is unavoidable, including cost/risk comparisons with FOSS options.'
+      deliverables:
+        - 'Full research dossier with explicit citations, risk register, and approval checklist.'
+        - 'Enterprise controls matrix referencing relevant standards (e.g., SOC2, ISO 27001, OWASP ASVS).'
+        - 'Mitigation playbooks and monitoring recommendations for launch + post-launch.'
 commands:
   - help: 'Display numbered command list for quick selection'
-  - validate-plan {artifact_path}: 'Run validate-plan-with-research.md to modernize the specified artifact'
-  - research-topic {topic}: 'Execute create-deep-research-prompt.md to investigate a focused topic'
+  - show-mode: 'Report the currently active mode, rationale, and key deliverables.'
+  - set-mode {solo|small-team|enterprise}: 'Switch operating mode per mode_protocol; restate deliverables and safeguards.'
+  - validate-plan {artifact_path}: 'Run validate-plan-with-research.md to modernize the specified artifact respecting the active mode.'
+  - research-topic {topic}: 'Execute create-deep-research-prompt.md tailored to the current mode to investigate a focused topic.'
+  - export-handoff {artifact_path?}: 'Produce a mode-appropriate handoff packet using the research-validation-log template and checklist.'
   - exit: 'Politely hand off and exit persona'
 dependencies:
   data:
@@ -50,8 +92,28 @@ dependencies:
   tasks:
     - create-deep-research-prompt.md
     - validate-plan-with-research.md
+  templates:
+    - research-validation-log.md
+  checklists:
+    - researcher-checklist.md
 operating_notes:
-  - 'Always append findings to a `## 🔬 Research & Validation Log` section in every artifact you touch.'
-  - 'When validating test designs, ensure coverage spans functional, negative, performance, and observability paths.'
+  - 'Always append findings to a `## 🔬 Research & Validation Log` section using the template and note the active mode.'
+  - 'When validating test designs, ensure coverage spans functional, negative, performance, resilience, and observability paths.'
   - 'Summaries must include explicitly cited sources (with access dates) and note any unresolved risks for downstream agents.'
+  - 'Prefer free and open-source tooling; when recommending a paid option, document why no FOSS alternative meets the requirement.'
+quality_gates:
+  - 'Cross-check medium/high-risk claims with at least two credible sources; capture confidence levels.'
+  - 'Reject outdated or end-of-life technologies; suggest modern replacements and migration steps.'
+  - 'Elevate security, privacy, and compliance issues immediately with explicit severity labels.'
+  - 'Ensure recommendations are actionable within the resource constraints implied by the active mode.'
+security_posture:
+  solo:
+    - 'Highlight critical security upgrades that can be shipped quickly (e.g., dependency patches, hardening flags).'
+    - 'Provide scripts or commands the developer can run locally without paid services.'
+  small-team:
+    - 'Advise on shared secrets management, CI policy checks, and rotating responsibilities.'
+    - 'Recommend integrating scanning tools into existing pipelines using FOSS options first.'
+  enterprise:
+    - 'Map findings to compliance controls, logging requirements, and segregation-of-duties needs.'
+    - 'Document audit evidence expectations and sign-off checkpoints.'
 ```

--- a/.bmad-core/tasks/validate-plan-with-research.md
+++ b/.bmad-core/tasks/validate-plan-with-research.md
@@ -2,42 +2,72 @@
 
 ## Purpose
 
-To automatically review a project artifact, conduct targeted research on its core concepts, apply updates to align the plan with modern best practices, and then report a summary of all changes made to the primary artifact and its companions.
+Automatically review a project artifact, conduct targeted research on its core concepts, apply updates to align the plan with modern best practices, and then report a summary of all changes made to the primary artifact and its companions. The scope and deliverables must respect the researcher's active mode (`solo`, `small-team`, or `enterprise`).
 
 ## Inputs
 
-- `artifact_path`: The file path to the primary project artifact to be validated (e.g., `docs/stories/1.1.setup-initial-project.md`).
+- `artifact_path`: File path to the primary project artifact to be validated (e.g., `docs/stories/1.1.setup-initial-project.md`).
+- `active_mode`: Optional override (`solo`|`small-team`|`enterprise`). Default is `solo` when omitted.
+
+## Mode Controls
+
+Before modification, note the current mode and adjust depth accordingly:
+
+- **Solo mode (default):**
+  - Prioritize high-impact, low-effort fixes and quick automation wins.
+  - Keep documentation lean: update the research log and list the top three follow-up actions.
+  - Favor free/open-source tooling; only suggest paid services with rationale and migration notes.
+- **Small-team mode:**
+  - Capture decisions that teammates need for code review, CI/CD, and ops handoffs.
+  - Produce a change summary with owners/reviewers and flag dependencies requiring alignment.
+  - Recommend FOSS-first solutions that integrate cleanly with lightweight SaaS if unavoidable.
+- **Enterprise mode:**
+  - Perform exhaustive validation covering security, compliance, reliability, and governance.
+  - Create an audit-ready dossier: include risk register entries, control mappings, and rollback plans.
+  - Document data handling, monitoring, and separation-of-duties requirements; note cost/risk trade-offs when paid tooling is involved.
+
+## Prerequisites
+
+- Load the `researcher-checklist.md` and review items relevant to the active mode.
+- Ensure the `research-validation-log.md` template is available for updating artifacts.
 
 ## Process (Must be followed sequentially)
 
 ### 1. Acknowledge and Load Artifact
 
-- Announce the task start and the specific artifact being reviewed.
+- Announce task start, active mode, and the artifact being reviewed.
 - Load the content of the file specified in `artifact_path`.
 
 ### 2. Contextual Analysis of Artifact
 
-- Determine the type of artifact being reviewed (e.g., Story, Test Design).
-- Tailor the research focus based on the artifact type:
-  - **For a Story:** Focus on implementation details, technologies, security, and performance patterns.
-  - **For a Test Design:** Focus on testing methodologies, frameworks, and coverage strategies.
+- Determine the type of artifact being reviewed (e.g., Story, Test Design, Architecture Doc).
+- Tailor emphasis based on artifact type:
+  - **Story:** Focus on implementation details, security, performance, and release readiness.
+  - **Test Design:** Emphasize testing methodologies, frameworks, resilience, and observability coverage.
+  - **Architecture/Plan:** Assess alignment with reference architectures, scalability, and compliance.
 
 ### 3. Identify Key Concepts for Research
 
-- Parse the artifact to identify key technical concepts, patterns, or strategies that require validation.
+- Parse the artifact to identify core technical concepts, patterns, dependencies, or strategies that require validation.
+- Bucket concepts by risk level (critical, moderate, informational) and note required source depth per mode.
 
 ### 4. Generate & Execute Research
 
-- For each concept, use the `create-deep-research-prompt.md` task to formulate a precise research question.
-- Execute the research and synthesize the findings into a concise summary of current best practices, including alternatives and common pitfalls.
+- For each concept, use the `create-deep-research-prompt.md` task tailored to the active mode to formulate precise research questions.
+- Execute research and synthesize findings into concise best-practice summaries, including alternatives and common pitfalls.
+- Cross-check medium/high-risk findings with at least two credible sources; record citations with access dates.
+- Prefer open documentation, standards bodies, and widely adopted FOSS tooling when recommending solutions.
 
 ### 5. Formulate Changes and Update Artifacts
 
-- Compare the research findings with the plan outlined in the primary artifact.
-- Formulate a specific list of changes (modifications, additions, removals) needed to align the plan with best practices.
-- **Automatically apply these changes directly to the primary artifact file.**
-- **Identify and load any accompanying documents** (e.g., risk profiles, test designs with a matching story ID) and apply any relevant cascading changes.
-- For each modified artifact, add or append to a changelog section (e.g., `## 🔬 Research & Validation Log`) detailing the exact changes made, the rationale, and the date.
+- Compare research findings with the plan outlined in the primary artifact.
+- Formulate a specific list of changes needed to align the plan with best practices and mode requirements.
+- **Apply the updates directly to the primary artifact file.**
+- **Identify and load any companion documents** (e.g., risk profiles, test designs with matching story ID) and apply cascading changes.
+- For each modified artifact:
+  - Append or update the `## 🔬 Research & Validation Log` section using the `research-validation-log.md` template.
+  - Note the active mode, decision rationale, confidence level, and residual risks.
+  - Document tooling recommendations with FOSS-first alternatives.
 
 ### 6. Generate Final Summary Report
 
@@ -48,6 +78,7 @@ To automatically review a project artifact, conduct targeted research on its cor
 **Research & Validation Summary**
 
 - **Primary Artifact Validated:** `{{artifact_path}}`
+- **Active Mode:** `{{active_mode}}`
 - **Status:** Complete. Artifacts have been updated automatically.
 
 **Modified Files:**
@@ -56,10 +87,17 @@ To automatically review a project artifact, conduct targeted research on its cor
 
 **Summary of Changes:**
 
-- **Modernization:** Updated the authentication strategy in the story to use passwordless WebAuthn, which is the current industry standard for security and user experience.
-- **Security Enhancement:** Added a task to the story to implement Content Security Policy (CSP) headers, based on research showing their effectiveness against XSS attacks.
-- **Test Plan Improvement:** Modified the `test-design.md` to include visual regression testing, as research indicated this is a best practice for component libraries of this type.
+- **Modernization:** {{mode-aware modernization summary with citations}}
+- **Security & Compliance:** {{security/compliance findings; include control mappings for enterprise mode}}
+- **Testing & Quality:** {{test coverage changes, tooling updates}}
+- **Operational Follow-ups:** {{owners, next steps, deadlines}}
 
-_For a detailed breakdown of every change, please see the "Research & Validation Log" section in the primary artifact._
+_For a detailed breakdown of every change, see the "Research & Validation Log" section in each modified artifact. Refer to the researcher checklist to confirm that all items for `{{active_mode}}` are satisfied._
 
 ---
+
+## Completion Criteria
+
+- All relevant artifacts updated with mode-appropriate research logs and citations.
+- Summary report delivered with clear next steps and ownership.
+- Researcher checklist items for the active mode verified and noted in the log.

--- a/bmad-core/checklists/researcher-checklist.md
+++ b/bmad-core/checklists/researcher-checklist.md
@@ -1,0 +1,37 @@
+<!-- Powered by BMAD™ Core -->
+
+# Researcher Checklist
+
+Use this checklist to confirm research and validation work meets the baseline hygiene requirements for the active mode. When executing tasks, reference the sections that match the current mode (`solo`, `small-team`, `enterprise`).
+
+## Global Hygiene
+
+- [ ] Document the active mode and rationale in the research log.
+- [ ] Cite all key findings with source, publisher, and access date (prefer open standards/community sources).
+- [ ] Cross-check medium/high-risk claims with at least two credible references.
+- [ ] Flag deprecated, end-of-life, or insecure patterns and propose modern alternatives.
+- [ ] Note residual risks, confidence levels, and required follow-up owners.
+- [ ] Prefer FOSS tooling; justify any paid solution with cost, benefit, and migration plan.
+- [ ] Store research artifacts using the `research-validation-log.md` template.
+
+## Solo Mode Focus
+
+- [ ] Highlight top three actions that unlock immediate progress for a single developer.
+- [ ] Provide automation scripts or CLI snippets where possible.
+- [ ] Ensure recommendations account for budget/time constraints typical of indie projects.
+- [ ] Include a quick rollback or mitigation approach for each high-risk change.
+
+## Small-Team Focus
+
+- [ ] Assign owners/reviewers for each major recommendation (RACI-style).
+- [ ] Map recommendations to CI/CD, code review, and documentation touchpoints.
+- [ ] Capture dependency upgrades with testing/automation status.
+- [ ] Identify collaboration or knowledge-sharing needs (demos, playbooks, docs).
+
+## Enterprise Focus
+
+- [ ] Map findings to relevant compliance or security controls (e.g., SOC2, ISO 27001, OWASP ASVS).
+- [ ] Provide threat model updates and monitoring/logging guidance.
+- [ ] Document data classification, retention, and access control impacts.
+- [ ] Record sign-off checkpoints, required stakeholders, and audit evidence locations.
+- [ ] Provide rollback, incident response, and change management considerations.

--- a/bmad-core/tasks/create-deep-research-prompt.md
+++ b/bmad-core/tasks/create-deep-research-prompt.md
@@ -14,6 +14,14 @@ Generate well-structured research prompts that:
 - Guide systematic investigation of complex topics
 - Ensure actionable insights are captured
 
+## Mode Awareness
+
+Always tailor the prompt to the researcher’s active mode:
+
+- **Solo (default):** Emphasize low-overhead research with fast, high-impact wins. Highlight FOSS-first tools, automation scripts, and deprioritize bureaucracy.
+- **Small-team:** Balance depth with knowledge sharing. Capture owner/reviewer assignments, CI/CD touchpoints, and lightweight governance artifacts.
+- **Enterprise:** Require exhaustive coverage, compliance control mapping, and audit-ready documentation. Call out data classification, sign-off checkpoints, and vendor due diligence.
+
 ## Research Type Selection
 
 CRITICAL: First, help the user select the most appropriate research focus based on their needs and any input documents they've provided.
@@ -119,6 +127,10 @@ CRITICAL: collaborate with the user to articulate clear, specific objectives for
 - Key decisions the research will inform
 - Success criteria for the research
 - Constraints and boundaries
+- **Mode considerations:**
+  - Solo → Focus on immediate implementation guidance and risk triage.
+  - Small-team → Capture collaboration touchpoints, ownership, and shared artifacts.
+  - Enterprise → Include compliance, governance, and audit evidence requirements.
 
 #### B. Research Questions
 
@@ -129,12 +141,20 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Central questions that must be answered
 - Priority ranking of questions
 - Dependencies between questions
+- **Mode considerations:**
+  - Solo → Prioritize questions that unblock development quickly.
+  - Small-team → Add questions about process integration, release readiness, and shared tooling.
+  - Enterprise → Expand to regulatory obligations, threat modeling, and long-term scalability.
 
 **Supporting Questions:**
 
 - Additional context-building questions
 - Nice-to-have insights
 - Future-looking considerations
+- **Mode considerations:**
+  - Solo → Capture backlog ideas with clear ROI.
+  - Small-team → Identify knowledge gaps between functions (dev, ops, product).
+  - Enterprise → Surface cross-org dependencies, change management, and vendor impacts.
 
 #### C. Research Methodology
 
@@ -144,6 +164,10 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Primary research approaches (if applicable)
 - Data quality requirements
 - Source credibility criteria
+- **Mode considerations:**
+  - Solo → Emphasize open docs, standards bodies, and community knowledge bases.
+  - Small-team → Add lightweight interviews or async surveys with stakeholders.
+  - Enterprise → Require authoritative standards, legal guidance, and formal approvals.
 
 **Analysis Frameworks:**
 
@@ -151,6 +175,10 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Comparison criteria
 - Evaluation methodologies
 - Synthesis approaches
+- **Mode considerations:**
+  - Solo → Leverage simplified scoring matrices for fast prioritization.
+  - Small-team → Incorporate frameworks that aid group decision-making (e.g., RICE, DACI).
+  - Enterprise → Use risk matrices, compliance control mapping, and cost-benefit analyses.
 
 #### D. Output Requirements
 
@@ -160,6 +188,10 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Detailed findings structure
 - Visual/tabular presentations
 - Supporting documentation
+- **Mode considerations:**
+  - Solo → Provide concise action lists and automation scripts/snippets.
+  - Small-team → Include handoff packets, change summaries, and owner/reviewer tables.
+  - Enterprise → Produce audit trails, risk registers, and linkage to corporate standards.
 
 **Key Deliverables:**
 
@@ -167,6 +199,7 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Decision-support elements
 - Action-oriented recommendations
 - Risk and uncertainty documentation
+- **FOSS-first guidance:** Always prefer open-source tooling; document justification when recommending paid services.
 
 ### 4. Prompt Generation
 
@@ -176,6 +209,12 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 ## Research Objective
 
 [Clear statement of what this research aims to achieve]
+
+## Active Mode
+
+- Operating mode: [solo | small-team | enterprise]
+- Resource & time constraints: [hours, budget, access limits]
+- Collaboration & approvals: [owners, reviewers, stakeholders]
 
 ## Background Context
 
@@ -199,15 +238,20 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 
 ### Information Sources
 
-- [Specific source types and priorities]
+- [Priority source types: standards bodies, OSS docs, vendor references]
 
 ### Analysis Frameworks
 
-- [Specific frameworks to apply]
+- [Frameworks/models tuned to the active mode]
 
 ### Data Requirements
 
 - [Quality, recency, credibility needs]
+
+## Tooling & Source Preferences
+
+- Preferred FOSS tools/platforms: [...]
+- Paid tooling (if unavoidable) + justification: [...]
 
 ## Expected Deliverables
 
@@ -215,17 +259,23 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 
 - Key findings and insights
 - Critical implications
-- Recommended actions
+- Recommended actions with owners
 
 ### Detailed Analysis
 
-[Specific sections needed based on research type]
+[Specific sections needed based on research type and mode]
 
 ### Supporting Materials
 
-- Data tables
-- Comparison matrices
-- Source documentation
+- Data tables / comparison matrices
+- Source documentation with access dates
+- Risk register or checklist excerpts
+
+## Governance & Risk
+
+- Compliance or security considerations
+- Monitoring / observability requirements
+- Residual risks and open questions
 
 ## Success Criteria
 
@@ -233,7 +283,7 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 
 ## Timeline and Priority
 
-[If applicable, any time constraints or phasing]
+[Time constraints, review cadence, follow-up milestones]
 ```
 
 ### 5. Review and Refinement
@@ -241,12 +291,12 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 1. **Present Complete Prompt**
    - Show the full research prompt
    - Explain key elements and rationale
-   - Highlight any assumptions made
+   - Highlight how the prompt satisfies the active mode requirements
 
 2. **Gather Feedback**
    - Are the objectives clear and correct?
    - Do the questions address all concerns?
-   - Is the scope appropriate?
+   - Is the scope appropriate for the active mode?
    - Are output requirements sufficient?
 
 3. **Refine as Needed**
@@ -269,6 +319,7 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Which team members should review results
 - How to validate findings
 - When to revisit or expand research
+- Which checklist items (from `researcher-checklist.md`) must be completed for the selected mode
 
 ## Important Notes
 
@@ -276,5 +327,7 @@ CRITICAL: collaborate with the user to develop specific, actionable research que
 - Be specific rather than general in research questions
 - Consider both current state and future implications
 - Balance comprehensiveness with focus
-- Document assumptions and limitations clearly
+- Document assumptions, limitations, and confidence levels clearly
 - Plan for iterative refinement based on initial findings
+- Always log the active mode and cite sources with access dates to maintain traceability
+- Favor open-source tooling; when recommending paid solutions, provide cost/risk comparison and migration path

--- a/bmad-core/templates/research-validation-log.md
+++ b/bmad-core/templates/research-validation-log.md
@@ -1,0 +1,43 @@
+<!-- Powered by BMAD™ Core -->
+
+# Research & Validation Log Template
+
+Use this template when appending a `## 🔬 Research & Validation Log` section to any artifact. Duplicate the structure for each validation session.
+
+```markdown
+## 🔬 Research & Validation Log ({{date}})
+
+- **Researcher:** {{name or agent id}}
+- **Active Mode:** {{solo|small-team|enterprise}}
+- **Primary Artifact:** {{artifact path}}
+- **Summary:** {{2-3 sentence recap of key findings}}
+
+### Findings & Actions
+
+| Priority | Area      | Recommended Change | Owner / Reviewer         | Confidence       | Sources                                  |
+| -------- | --------- | ------------------ | ------------------------ | ---------------- | ---------------------------------------- |
+| High     | {{topic}} | {{action}}         | {{owner}} / {{reviewer}} | {{High/Med/Low}} | [{{Source 1}}](URL), [{{Source 2}}](URL) |
+
+### Tooling Guidance
+
+- **FOSS-first Recommendation:** {{tool or approach}}
+- **Paid Option (if required):** {{name}} — justification & mitigation plan
+- **Automation / Scripts:** {{commands, links, or references}}
+
+### Risk & Compliance Notes
+
+- **Residual Risks:** {{list with severity}}
+- **Compliance / Control Mapping:** {{relevant standards or policies}}
+- **Monitoring / Observability:** {{logs, alerts, dashboards}}
+- **Rollback / Contingency:** {{steps}}
+
+### Follow-Up Tasks
+
+- [ ] {{task}} — Owner: {{name}}, Due: {{date}}
+- [ ] {{task}} — Owner: {{name}}, Due: {{date}}
+
+### Source Appendix
+
+1. {{Source Title}} — {{Publisher}} (Accessed {{YYYY-MM-DD}})
+2. {{Source Title}} — {{Publisher}} (Accessed {{YYYY-MM-DD}})
+```

--- a/docs/researcher-mode-strategy.md
+++ b/docs/researcher-mode-strategy.md
@@ -1,0 +1,37 @@
+# Researcher Agent Refactor Plan
+
+## Objectives
+
+- Introduce selectable operating modes tuned for solo developers (default), small teams, and enterprise programs.
+- Strengthen sourcing, compliance, and documentation practices across all research work.
+- Keep workflows efficient while favoring free and open-source tooling where practical.
+
+## Key Improvements
+
+- **Mode awareness:** Add mode negotiation on activation with default `solo`; allow user to switch to `small-team` or `enterprise` explicitly.
+- **Hygiene baseline:** Require standardized research log entries, de-duplication of findings, and explicit confidence + risk notes.
+- **Source governance:** Mandate cross-checking of claims with at least two credible sources when risk is medium/high.
+- **Security posture:** Elevate guidance for threat modeling, dependency risk, and data handling in higher modes.
+- **Collaboration assets:** Share reusable prompt, log, and checklist assets to align downstream agents.
+- **FOSS-first tooling:** Provide vetted open-source options before suggesting paid services; flag when paid vendors are unavoidable.
+
+## Mode Profiles
+
+| Mode         | Default Audience                    | Scope & Depth                                                                            | Collaboration                                                 | Risk & Compliance                                                | Output Targets                                              |
+| ------------ | ----------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------- |
+| `solo`       | Solo devs and indie maintainers     | Focus on actionable, low-overhead upgrades; highlight quick wins and critical fixes only | Lightweight notes; optional handoff packets                   | Emphasize security/privacy basics                                | Concise research log with prioritized next steps            |
+| `small-team` | Squads ≤10 engineers                | Balance depth with maintainable processes; ensure shared understanding                   | Shared research workspace outline; highlight owner + reviewer | Introduce dependency tracking and lightweight policy checks      | Research log + change summary ready for team review         |
+| `enterprise` | Regulated / security-sensitive orgs | Exhaustive validation; ensure compliance and auditability                                | Formal documentation, handoff checklists, RACI callouts       | Require compliance references, threat models, and rollback plans | Mode-specific dossier including risk register and approvals |
+
+## Artifacts to Update
+
+1. `.bmad-core/agents/researcher.md`
+2. `.bmad-core/tasks/validate-plan-with-research.md`
+3. `bmad-core/tasks/create-deep-research-prompt.md`
+4. `bmad-core/checklists/researcher-checklist.md` (new)
+5. Supporting docs/templates as needed (e.g., research log scaffolding)
+
+## Open Questions
+
+- Should workflows auto-switch mode based on artifact tags? → Future enhancement.
+- Do we need a distribution copy under `dist/agents`? → Evaluate during implementation.


### PR DESCRIPTION
## Summary
- introduce mode selection (solo, small-team, enterprise) to the researcher agent with supporting commands and safeguards
- update validate-plan and prompt creation tasks to respect the active mode and use new guidance assets
- add reusable researcher checklist, research validation log template, and design notes documenting the rollout plan

## Testing
- npm run lint