### PR TITLE
chore(ci): remove reviewer artifacts after telemetry sync

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -233,6 +233,10 @@ jobs:
           sync_metrics "default" "reviewer-default" "default"
           sync_metrics "strict" "reviewer-strict" "strict"
 
+      - name: Cleanup downloaded reviewer artifacts
+        if: always()
+        run: rm -rf reviewer-default reviewer-strict
+
       - name: Commit telemetry update
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- delete reviewer-default/strict artifacts after telemetry sync to keep tree clean

## Testing
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI reliability: Added an unconditional cleanup step to the telemetry update workflow that removes temporary reviewer artifacts after syncing. This ensures a clean workspace for subsequent tasks and reduces risk of conflicts between runs.
  * The cleanup runs regardless of previous step outcomes, preventing leftover files from affecting future executions and improving overall workflow stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->