### PR TITLE
Close release governance epic follow-ups

### DIFF
--- a/docs/bmad/focused-epics/release-governance/epic.md
+++ b/docs/bmad/focused-epics/release-governance/epic.md
@@ -73,5 +73,5 @@ Re-align the chat-mcp-farm release workflow so it mirrors the upstream BMAD patt
 
 ### Follow-Up Tasks
 
-- [ ] Confirm version bump rules align with conventional commits.
-- [ ] Decide whether to attach build artifacts (e.g., tarballs) to releases.
+- [x] Confirm version bump rules align with conventional commits. (Docs: `docs/release-automation.md#version-mapping-quick-reference`, validated via `semantic-release --dry-run` during run 18024216996.)
+- [x] Decide whether to attach build artifacts (e.g., tarballs) to releases. (Decision: continue shipping only the default `@semantic-release/npm` tarball for `bmad-drj`; no additional build artifacts required as of release `v1.1.0`. Re-evaluate when new distributables exist.)


### PR DESCRIPTION
## Summary
- check off remaining release governance epic follow-ups now that story 1.4 evidence run is merged on main
- document that conventional-commit version mapping has been validated and that we intentionally ship only the default tarball (no extra build artifacts yet)

## Testing
- npm run format:check
- npm run lint