### PR TITLE
fix: format manual release notes in CI

### DIFF
--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -129,7 +129,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Format release notes
-        run: prettier --write release_notes.md
+        run: npx prettier --write release_notes.md
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
## Summary
- run prettier --write release_notes.md during the Manual Release workflow so the husky pre-push hook passes

## Testing
- npm run pre-release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated formatting step that standardizes generated release notes before publishing.

* **Documentation**
  * Release notes now appear with consistent, polished formatting for improved readability.
  * No functional changes to the product experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->